### PR TITLE
Fix compilation errors:

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -176,8 +176,6 @@ class Linux {
   // Return the namespace pid if so, otherwise -1.
   static int get_namespace_pid(int vmid);
 
-  static int checkpoint_restore(int *shmid);
-
   // Stack repair handling
 
   // none present

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -69,6 +69,7 @@
 #include "prims/stackwalk.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/crac.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -44,6 +44,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/crac.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/flags/jvmFlagAccess.hpp"
 #include "runtime/flags/jvmFlagLimit.hpp"

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -77,6 +77,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/biasedLocking.hpp"
+#include "runtime/crac.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/flags/jvmFlagLimit.hpp"
 #include "runtime/deoptimization.hpp"

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -41,6 +41,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "oops/typeArrayOop.inline.hpp"
+#include "runtime/crac.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"


### PR DESCRIPTION
commit 5d2fe3461534d56b0408788c8d7c1b94f85530c0
```
../../src/hotspot/share/runtime/arguments.cpp: In static member function 'static jint Arguments::finalize_vm_init_args(bool)': ../../src/hotspot/share/runtime/arguments.cpp:3235:28: error: 'crac' has not been declared
 3235 |   if (CRaCCheckpointTo && !crac::prepare_checkpoint()) {
      |                            ^~~~

../../src/hotspot/share/prims/jvm.cpp: In function '_jobjectArray* JVM_Checkpoint(JNIEnv*, jarray, jobjectArray, jboolean, jlong)': ../../src/hotspot/share/prims/jvm.cpp:3853:16: error: 'crac' has not been declared
 3853 |   Handle ret = crac::checkpoint(fd_arr, obj_arr, dry_run, jcmd_stream, CHECK_NULL);
      |                ^~~~
../../src/hotspot/share/services/management.cpp: In function 'jlong get_long_attribute(jmmLongAttribute)':
../../src/hotspot/share/services/management.cpp:957:12: error: 'crac' has not been declared
  957 |     return crac::restore_start_time();
      |            ^~~~
../../src/hotspot/share/services/management.cpp:961:21: error: 'crac' has not been declared
  961 |       jlong ticks = crac::uptime_since_restore();
      |                     ^~~~
```
Remove a no longer used declaration of `os::Linux::checkpoint_restore()`.